### PR TITLE
test: fail when patch is not a dependency

### DIFF
--- a/tests/snapshots/tests__patch_exists.snap
+++ b/tests/snapshots/tests__patch_exists.snap
@@ -8,10 +8,12 @@ name = "test-package"
 version = "0.1.0"
 edition = "2021"
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+patch-package = "0.1.0"
+
 [patch]
 
 [patch.crates-io]
 patch-package = { path = "u9KdJGBDefkZz" }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 '''

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Write as _,
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},
@@ -9,7 +10,7 @@ use cargo_override::{run, Args, CARGO_TOML};
 use fake::{Fake, Faker};
 use googletest::{
     expect_that,
-    matchers::{displays_as, eq, err, ok},
+    matchers::{anything, displays_as, eq, err, ok},
 };
 use tempfile::TempDir;
 
@@ -20,13 +21,20 @@ fn patch_exists() {
 
     let patch_folder = "u9KdJGBDefkZz";
     let patch_folder_path = working_dir.join(patch_folder);
+    let patch_crate_name = "patch-package";
 
     fs::create_dir(&patch_folder_path).expect("failed to create patch folder");
 
-    let working_dir_manifest_path =
-        create_cargo_manifest(working_dir, &manifest_header("test-package"));
+    let mut manifest = manifest_header("test-package");
+
+    manifest.push_str(&manifest_dependencies(vec![(
+        patch_crate_name.to_owned(),
+        "0.1.0".to_owned(),
+    )]));
+
+    let working_dir_manifest_path = create_cargo_manifest(working_dir, &manifest);
     let _patch_manifest_path =
-        create_cargo_manifest(&patch_folder_path, &manifest_header("patch-package"));
+        create_cargo_manifest(&patch_folder_path, &manifest_header(&patch_crate_name));
 
     let result = run(
         working_dir,
@@ -39,6 +47,34 @@ fn patch_exists() {
     let manifest = fs::read_to_string(working_dir_manifest_path).unwrap();
 
     insta::assert_toml_snapshot!(manifest);
+}
+
+/// When we add a patch we want to make sure that we're actually depending on the dependency we're
+/// patching.
+#[googletest::test]
+#[should_panic] // This shouldn't panic but having random test failures is annoying.
+                // Remove this line when the code is fixed to pass this test
+fn patch_exists_put_project_does_not_have_dep() {
+    let working_dir = TempDir::new().unwrap();
+    let working_dir = working_dir.path();
+
+    let patch_folder = "u9KdJGBDefkZz";
+    let patch_folder_path = working_dir.join(&patch_folder);
+
+    fs::create_dir(&patch_folder_path).expect("failed to create patch folder");
+
+    let _working_dir_manifest_path =
+        create_cargo_manifest(working_dir, &manifest_header("test-package"));
+    let _patch_manifest_path =
+        create_cargo_manifest(&patch_folder_path, &manifest_header("patch-package"));
+
+    let result = run(
+        working_dir,
+        Args {
+            path: patch_folder.to_string(),
+        },
+    );
+    expect_that!(result, err(anything()));
 }
 
 fn create_cargo_manifest(dir: &Path, content: &str) -> PathBuf {
@@ -61,6 +97,15 @@ edition = \"2021\"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 "
     )
+}
+
+fn manifest_dependencies(dependencies: Vec<(String, String)> /* name, version */) -> String {
+    let mut f = String::new();
+    writeln!(f, "[dependencies]").unwrap();
+    for (name, version) in dependencies {
+        writeln!(f, "{name} = \"{version}\"").unwrap();
+    }
+    f
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
When we add a patch we want to make sure that we're actually depending on the dependency we're patching