### PR TITLE
test: build insta in release mod

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,9 @@ fake = "2.9.2"
 googletest = "0.11.0"
 insta = { version = "1.38.0", features = ["toml"] }
 tempfile = "3.10.1"
+
+# Faster snapshotting https://insta.rs/docs/quickstart/#optional-faster-runs
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3
+


### PR DESCRIPTION
`cargo insta` recommends this for much faster tests https://insta.rs/docs/quickstart/#optional-faster-runs