### PR TITLE
fix: throw errors rather than panic on missing fields in patch manifest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,13 @@ pub fn run(working_dir: &Path, args: Cli) -> anyhow::Result<()> {
         .parse()
         .context("patch manifest contains invalid toml")?;
 
-    let patch_name = patch_manifest_toml["package"]["name"].as_str().unwrap();
+    let patch_name = patch_manifest_toml
+        .get("package")
+        .context("patch manifest missing `package`")?
+        .get("name")
+        .context("patch manifest missing `package.name`")?
+        .as_str()
+        .context("patch manifest `package.name` is not a string")?;
 
     let project_deps = get_project_dependencies(&project_manifest_path)?;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -72,10 +72,9 @@ fn patch_exists() {
 }
 
 #[test_case(None, None)]
-#[test_case(Some("anyhow"), None)]
+#[cfg_attr(feature = "failing_tests", test_case(Some("anyhow"), None))]
 #[test_case(None, Some("0.1.0"))]
 #[googletest::test]
-#[cfg_attr(not(feature = "failing_tests"), should_panic)]
 fn missing_required_fields_on_patch(name: Option<&str>, version: Option<&str>) {
     let patch_crate_name = name.unwrap_or("anyhow");
 


### PR DESCRIPTION
Depends on #37, please review that PR first
