### PR TITLE
fix: throw error when patch is missing version information

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,20 @@ pub fn run(working_dir: &Path, args: Cli) -> anyhow::Result<()> {
         .parse()
         .context("patch manifest contains invalid toml")?;
 
-    let patch_name = patch_manifest_toml
+    let patch_manifest_package = patch_manifest_toml
         .get("package")
-        .context("patch manifest missing `package`")?
+        .context("patch manifest missing `package`")?;
+
+    let patch_name = patch_manifest_package
         .get("name")
         .context("patch manifest missing `package.name`")?
         .as_str()
         .context("patch manifest `package.name` is not a string")?;
+
+    // TODO: we need to use this version to ensure that our patch is compatible #28
+    let _patch_version = patch_manifest_package
+        .get("version")
+        .context("patch manifest missing `package.version`")?;
 
     let project_deps = get_project_dependencies(&project_manifest_path)?;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -116,7 +116,7 @@ fn patch_version_incompatible(dependency_version: &str, patch_version: &str) {
 }
 
 #[test_case(None, None)]
-#[cfg_attr(feature = "failing_tests", test_case(Some("anyhow"), None))]
+#[test_case(Some("anyhow"), None)]
 #[test_case(None, Some("0.1.0"))]
 #[googletest::test]
 fn missing_required_fields_on_patch(name: Option<&str>, version: Option<&str>) {


### PR DESCRIPTION
> [!IMPORTANT]  
> Depends on #40, review that PR first

related: #28
