### PR TITLE
chore: support running `cargo_metadata` in offline mode

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -41,10 +41,13 @@ fn override_subcommand_help_message() {
 
             insta::assert_toml_snapshot!(output, @r###"
             '''
-            Usage: cargo override --path <PATH>
+            Usage: cargo override [OPTIONS] --path <PATH>
 
             Options:
               -p, --path <PATH>  
+                  --locked       Assert that `Cargo.lock` will remain unchanged
+                  --offline      Run without accessing the network
+                  --frozen       Equivalent to specifying both --locked and --offline
               -h, --help         Print help
             '''
             "###);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -297,6 +297,11 @@ fn patch_manifest_doesnt_exist() {
 
 fn override_path(path: impl Into<String>) -> Cli {
     Cli {
-        command: CargoInvocation::Override { path: path.into() },
+        command: CargoInvocation::Override {
+            path: path.into(),
+            frozen: true,
+            locked: false,
+            offline: false,
+        },
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #47 and #35, review those PRs first

resolves #44

Cargo shouldn't need to call the network for our purposes.
Calling the network only serves to make things fail more often.

Not calling the network is also going to make it easier to test private registries #32,
since we won't have to mock them anymore