### PR TITLE
chore: run `cargo_metadata` without fetching transative dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ fn get_project_dependencies(
 ) -> Result<Vec<Dependency>, anyhow::Error> {
     let mut cmd = cargo_metadata::MetadataCommand::new();
     cmd.manifest_path(project_manifest_path);
+    cmd.other_options(["--no-deps"].map(str::to_owned));
     let metadata = cmd.exec().context("Unable to run `cargo metadata`")?;
 
     let root_package = metadata.root_package().unwrap();


### PR DESCRIPTION
Fetching these can fail and we don't need them
