### PR TITLE
docs: specify version in install guide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-override"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = """

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First, ensure that you have a recent version of `cargo` installed.
 `cargo override` can then be installed with `cargo`.
 
 ```
-cargo install cargo-override --locked
+cargo install cargo-override@0.1.0-alpha.2 --locked
 ```
 
 Alternative installation methods will be avalible in the future.


### PR DESCRIPTION
otherwise cargo will not select an alpha release
