### PR TITLE
Leave alpha and release `0.0.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-override"
-version = "0.1.0-alpha.2"
+version = "0.0.1"
 edition = "2021"
 license = "Apache-2.0 OR MIT"
 description = """

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ First, ensure that you have a recent version of `cargo` installed.
 `cargo override` can then be installed with `cargo`.
 
 ```
-cargo install cargo-override@0.1.0-alpha.2 --locked
+cargo install cargo-override --locked
 ```
 
 Alternative installation methods will be avalible in the future.


### PR DESCRIPTION
This isn't a change in the status of the project, but simply a change to make `cargo-override` easier to install and update. Cargo doesn't select pre-release versions by default, leading to confusion
