### PR TITLE
Use `expect_eq` rather than `expect_that` where applicable

### DIFF
--- a/tests/all/git.rs
+++ b/tests/all/git.rs
@@ -7,7 +7,7 @@ use std::{env, path::Path};
 
 use assert_cmd::Command;
 use fs_err as fs;
-use googletest::{expect_that, matchers::eq};
+use googletest::{expect_eq, verify_eq, verify_that};
 use tempfile::TempDir;
 
 #[googletest::test]
@@ -268,7 +268,7 @@ fn git_patch_version_missmatch() {
 
     let manifest_after = fs::read_to_string(&manifest_path).unwrap();
 
-    expect_that!(manifest_before, eq(&manifest_after));
+    expect_eq!(manifest_before, manifest_after);
 }
 
 fn override_redact_crate(

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -20,7 +20,7 @@ use cargo_override::CARGO_TOML;
 use assert_cmd::Command;
 use fake::{Fake, Faker};
 use fs_err as fs;
-use googletest::{expect_that, matchers::eq};
+use googletest::{expect_eq, verify_eq, verify_that};
 use tempfile::TempDir;
 use test_case::test_case;
 
@@ -692,7 +692,7 @@ fn patch_version_incompatible(dependency_version: &str, patch_version: &str) {
 
     let manifest_after = fs::read_to_string(working_dir_manifest_path).unwrap();
 
-    expect_that!(manifest_before, eq(&manifest_after));
+    expect_eq!(manifest_before, manifest_after);
 }
 
 #[test_case(None, None)]
@@ -735,7 +735,7 @@ fn missing_required_fields_on_patch(name: Option<&str>, version: Option<&str>) {
 
     let manifest_after = fs::read_to_string(working_dir_manifest_path).unwrap();
 
-    expect_that!(manifest_before, eq(&manifest_after));
+    expect_eq!(manifest_before, manifest_after);
 }
 
 /// When we add a patch we want to make sure that we're actually depending on the dependency we're
@@ -783,7 +783,7 @@ fn patch_exists_put_project_does_not_depend_on_it() {
 
     let manifest_after = fs::read_to_string(working_dir_manifest_path).unwrap();
 
-    expect_that!(manifest_before, eq(&manifest_after));
+    expect_eq!(manifest_before, manifest_after);
 }
 
 #[googletest::test]


### PR DESCRIPTION
This requires extra imports because googletest macros look for items in the local scope.

I've opened a PR to fix this https://github.com/google/googletest-rust/pull/475

Once that is released, the extra imports will become unused.
