### PR TITLE
chore: Avoid rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.80.1"


### PR DESCRIPTION
This has a negative affect on cargo scripts in that they will be forced to recompile when run in this directory and then be recompiled again when not in this directory.