### PR TITLE
fix: Advertize MSRV in metadata

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,21 +54,19 @@ jobs:
       - name: cargo check
         run: cargo check --locked --all-features
   msrv:
+    name: "Check MSRV"
     runs-on: ubuntu-latest
-    # we use a matrix here just because env can't be used in job names
-    # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-    strategy:
-      matrix:
-        msrv: [1.78.0]
-    name: ubuntu / ${{ matrix.msrv }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Install ${{ matrix.msrv }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.msrv }}
-      - name: cargo +${{ matrix.msrv }} check
-        run: cargo check --all-features
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v2
+    - uses: taiki-e/install-action@cargo-hack
+    - name: Default features
+      run: cargo hack check --feature-powerset --locked --rust-version --ignore-private --workspace --all-targets
   lockfile:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cargo-override"
 version = "0.0.1"
 edition = "2021"
+rust-version = "1.79"
 license = "Apache-2.0 OR MIT"
 description = """
 Quickly override dependencies using the `[patch]` section of `Cargo.toml`s.


### PR DESCRIPTION
While CI claims to be checking 1.78, in actuality its 1.79 due to use of `path::absolute`.

Besides letting users know the MSRV, this will also allow clippy to report MSRV violations like `path::absolute`, during development.

This also fixes CI to actually check MSRV.  This is using `cargo hack`, as suggested in [Cargo's docs](https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-rust-version), to single-source the MSRV version.