### PR TITLE
fix(cli): Add missing style to usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,9 +449,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ camino = "1.1.9"
 cargo = "0.81.0"
 cargo_metadata = "0.18"
 cargo-util-schemas = "0.4.0"
-clap = { version = "4.4.4", features = ["derive"] }
+clap = { version = "4.5.17", features = ["derive"] }
 fs-err = "2.11.0"
 home = "0.5.9"
 pathdiff = "0.2.1"


### PR DESCRIPTION
We had a bug in clap where `<--path <PATH>|--git <URI>>` wasn't being styled