### PR TITLE
ci: fix non-specific action version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,6 @@ jobs:
       uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a
       with:
         toolchain: stable
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@v2.7.3
     - name: "Is lockfile updated?"
       run: cargo update --workspace --locked


### PR DESCRIPTION
This was missed in https://github.com/eopb/cargo-override/pull/125
