### PR TITLE
Git deps support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,9 @@ pub fn run(working_dir: &Path, args: Cli) -> anyhow::Result<()> {
         dependency.registry.as_deref()
     };
 
-    let registry = if let Some(registry_url) = &dependency_registry {
+    let registry = if let Some(repo) = &dependency.repo {
+        repo.to_owned()
+    } else if let Some(registry_url) = &dependency_registry {
         let registry_guess =
             registry::get_registry_name_from_url(manifest_dir.to_path_buf(), registry_url)
                 .context("failed to guess registry")?;


### PR DESCRIPTION
Addresses #146 

When patching a dependency which source is from git, it has to be patched with the git URL as the registry.