### PR TITLE
ci: move away from deprecated `magic-nix-cache-action`

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v9
+      - uses: DeterminateSystems/flakehub-cache-action@v1
       - run: nix flake check -L --show-trace
   fmt:
     runs-on: ubuntu-latest
@@ -33,5 +33,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v9
+      - uses: DeterminateSystems/flakehub-cache-action@v1
       - run: nix run nixpkgs#nixfmt-rfc-style -- --check flake.nix


### PR DESCRIPTION
```
Magic Nix Cache is deprecated

Magic Nix Cache has been deprecated due to a change in the underlying GitHub APIs and will stop working on 1 February 2025.
To continue caching Nix builds in GitHub Actions, use FlakeHub Cache instead.

Replace...
      - uses: DeterminateSystems/magic-nix-cache-action@v9

...with...
      - uses: DeterminateSystems/flakehub-cache-action@v9

For more details: https://dtr.mn/magic-nix-cache-eol
```
