### PR TITLE
fix(nix): legacy `darwin.apple_sdk_11_0`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,6 @@
         darwinDeps =
           with pkgs;
           lib.optionals stdenv.isDarwin [
-            darwin.apple_sdk.frameworks.Foundation
             libiconv
           ];
 


### PR DESCRIPTION
https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks
